### PR TITLE
fix: deprecates nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "nanoid": "^4.0.0",
     "react-animate-height": "^3.0.4",
     "react-transition-group": "^4.4.2"
   },

--- a/src/Collapsible/Provider/index.tsx
+++ b/src/Collapsible/Provider/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import CollapsibleContext, { ICollapsibleContext } from './context';
 import useCollapsibleGroup from '../../CollapsibleGroup/useCollapsibleGroup';
-import { nanoid } from 'nanoid'
+import { makeID } from '../../makeID';
 
 export const collapsibleBaseClass = 'collapsible';
 
@@ -37,10 +37,10 @@ const Collapsible: React.FC<CollapsibleProps> = (props) => {
   const [prevGroupToggleCount, setPrevGroupToggleCount] = useState(0);
 
   // NOTE: the 'aria-owns' and 'aria-labelledby' attributes rely on this matching IDs
-  const [id, setID] = useState(() => idFromProps || nanoid(6));
+  const [id, setID] = useState(() => idFromProps || makeID(5));
 
   useEffect(() => {
-    setID(idFromProps || nanoid(6));
+    setID(idFromProps || makeID(5));
   }, [idFromProps])
 
   useEffect(() => {

--- a/src/makeID.ts
+++ b/src/makeID.ts
@@ -1,0 +1,14 @@
+export const makeID = (length: number) => {
+  let result = '';
+
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+
+  characters.split('').forEach((char, index) => {
+    if (index < length) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+  });
+
+  return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3883,11 +3883,6 @@ multicast-dns@^7.2.5:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
 
-nanoid@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.0.tgz#6e144dee117609232c3f415c34b0e550e64999a5"
-  integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
Replaces `nanoid`. See [this issue](https://github.com/ai/nanoid/issues/365).